### PR TITLE
Bugfix/random place

### DIFF
--- a/annotateFromVideo.py
+++ b/annotateFromVideo.py
@@ -462,9 +462,8 @@ for j, video_file in enumerate(video_files):
                     # backImgに合わせるときにyがはみ出ないか
                     elif backImg.shape[0] <= addY + y or addY + y < 0:
                         continue
-
-                    # print(x,y,addX,addY)
-                    if (affine_img[y][x][0] + affine_img[y][x][1] + affine_img[y][x][2]) != 0:  # TODO:out of rangeの発生を防ぐ
+                    # TODO:out of rangeの発生を防ぐ
+                    elif affine_img[y][x][0] != 0 or affine_img[y][x][1] != 0 or affine_img[y][x][2] != 0:
                         backImg[addY + y][addX + x] = affine_img[y][x]
 
             visualizedImg = backImg.copy()

--- a/annotateFromVideo.py
+++ b/annotateFromVideo.py
@@ -448,10 +448,10 @@ for j, video_file in enumerate(video_files):
 
             # ランダムに上下左右に対象物の位置を移動させる
             # オブジェクトが画面外に出るのを防ぐためエッジ付近への配置を禁止する（オブジェクト動画が常に画面中央を通る場合は不要）
-            x_edge_margin = affine_img.shape[0]/4
-            y_edge_margin = affine_img.shape[1]/4
-            addX = int(random.uniform(x_edge_margin, backW - x_edge_margin) - affine_img.shape[0]/2)
-            addY = int(random.uniform(y_edge_margin, backH - y_edge_margin) - affine_img.shape[1]/2)
+            x_edge_margin = affine_img.shape[1]/8
+            y_edge_margin = affine_img.shape[0]/8
+            addX = int(random.uniform(x_edge_margin, backW - x_edge_margin) - affine_img.shape[1]/2)
+            addY = int(random.uniform(y_edge_margin, backH - y_edge_margin) - affine_img.shape[0]/2)
 
             # コントローラを重畳する
             for y in range(affine_img.shape[0]):

--- a/annotateFromVideo.py
+++ b/annotateFromVideo.py
@@ -422,9 +422,9 @@ for j, video_file in enumerate(video_files):
 
         for count in range(10):
             scale = random.uniform(0.6, 1.2)
+            degree = random.uniform(-30, 30)
             objectW = smallWidth
             objectH = smallHeight
-            degree = random.uniform(-30, 30)
             randomMat = cv2.getRotationMatrix2D(
                 (int(objectW/2), int(objectH/2)), degree, scale)
             print(randomMat)

--- a/annotateFromVideo.py
+++ b/annotateFromVideo.py
@@ -447,9 +447,11 @@ for j, video_file in enumerate(video_files):
             backImg = cv2.resize(backImg, (backW, backH))
 
             # ランダムに上下左右に対象物の位置を移動させる
-            backEdgeMargin = 0.1
-            addX = int( (1.0 - backEdgeMargin) * random.uniform(- backW / 2, backW / 2) )
-            addY = int( (1.0 - backEdgeMargin) * random.uniform(- backH / 2, backH / 2) )
+            # オブジェクトが画面外に出るのを防ぐためエッジ付近への配置を禁止する（オブジェクト動画が常に画面中央を通る場合は不要）
+            x_edge_margin = affine_img.shape[0]/4
+            y_edge_margin = affine_img.shape[1]/4
+            addX = int(random.uniform(x_edge_margin, backW - x_edge_margin) - affine_img.shape[0]/2)
+            addY = int(random.uniform(y_edge_margin, backH - y_edge_margin) - affine_img.shape[1]/2)
 
             # コントローラを重畳する
             for y in range(affine_img.shape[0]):

--- a/annotateFromVideo.py
+++ b/annotateFromVideo.py
@@ -465,7 +465,7 @@ for j, video_file in enumerate(video_files):
                         continue
 
                     # print(x,y,addX,addY)
-                    if affine_img[y][x][0] != 0:  # TODO:out of rangeの発生を防ぐ
+                    if affine_img[y][x][0] != 0 or affine_img[y][x][1] != 0 or affine_img[y][x][2] != 0:  # TODO:out of rangeの発生を防ぐ
                         backImg[addY + y][addX + x] = affine_img[y][x]
 
             visualizedImg = backImg.copy()


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

<!-- 変更の目的 または 概要-->
## Summary
fix #9
fix #2 
- 背景合成時にオブジェクトの位置をランダムに与える部分の範囲を修正
  - 回転中心をランダムにして回転変換した後、更にランダム配置していた
    - →回転中心は画像の中心に固定
  - 背景画像のサイズ内でランダムに選んだピクセルから開始し、オブジェクト画像の原点（左上）にしていた
    - →オブジェクトが右下に隠れる場合があった
    - →オブジェクト画像の中心をランダム配置するように変更
  - ~~上記を解決しても、オブジェクト動画で中心に撮影されてない場合に画面外に出る~~
    - ~~→ランダム配置の値の範囲を制限し、背景画像のエッジ付近に配置しないように変更~~
- ~~該当処理内の変数名を一部変更~~

## TODO（時間がかかりそうなので別issueにて対応予定）
- オブジェクトの図心を取るようにし、元動画に依存せずランダム配置できるようにしたい
- キャンパスサイズを変更せずにアフィン変換しているため、大きいオブジェクトは画像を拡大したときに一部見切れる

## 05/18追記
- マージ作業簡単にするためリファクタリングをもとに戻した
